### PR TITLE
Terraform for さくらのクラウド v0.9.0対応

### DIFF
--- a/1-one-server/one-server.tf
+++ b/1-one-server/one-server.tf
@@ -17,10 +17,7 @@ resource "sakuracloud_disk" "disk01"{
 
 
 data sakuracloud_archive "centos" {
-    filter = {
-        name   = "Tags"
-        values = ["current-stable", "arch-64bit", "distro-centos"]
-    }
+    os_type = "centos"
 }
 
 resource "sakuracloud_ssh_key" "key"{
@@ -30,7 +27,7 @@ resource "sakuracloud_ssh_key" "key"{
 }
 
 output "server_ip" {
-   value = "${sakuracloud_server.server01.base_nw_ipaddress}"
+   value = "${sakuracloud_server.server01.ipaddress}"
 }
 
 

--- a/2-dev-server/dev-server.tf
+++ b/2-dev-server/dev-server.tf
@@ -1,4 +1,3 @@
-
 resource "sakuracloud_server" "dev01" {
     name = "dev01"
     disks = ["${sakuracloud_disk.dev01.id}"]
@@ -8,23 +7,23 @@ resource "sakuracloud_server" "dev01" {
     provisioner "remote-exec" {
         connection {
             type = "ssh"
-	    user = "root"
-            host = "${sakuracloud_server.dev01.base_nw_ipaddress}"
+            user = "root"
+            host = "${self.ipaddress}"
             private_key = "${file("~/.ssh/id_rsa")}"
         }
         inline = [
-		"yum -y update",
-		"yum -y install httpd",
-		"systemctl enable httpd",
-		"systemctl start httpd",
-		"echo hello, this is ${sakuracloud_server.dev01.base_nw_ipaddress} > /var/www/html/index.html",
-		"firewall-cmd --add-port=80/tcp --permanent",
-		"firewall-cmd --reload"
+            "yum -y update",
+            "yum -y install httpd",
+            "systemctl enable httpd",
+            "systemctl start httpd",
+            "echo hello, this is ${self.ipaddress} > /var/www/html/index.html",
+            "firewall-cmd --add-port=80/tcp --permanent",
+            "firewall-cmd --reload"
         ]
     }
 }
 
-resource "sakuracloud_disk" "dev01"{
+resource "sakuracloud_disk" "dev01" {
     name = "dev01"
     hostname = "dev01"
     source_archive_id = "${data.sakuracloud_archive.centos.id}"
@@ -36,10 +35,7 @@ resource "sakuracloud_disk" "dev01"{
 
 
 data sakuracloud_archive "centos" {
-    filter = {
-        name   = "Tags"
-        values = ["current-stable", "arch-64bit", "distro-centos"]
-    }
+    os_type = "centos"
 }
 
 resource "sakuracloud_ssh_key" "key"{

--- a/3-simple-monitoring/simple-monitoring.tf
+++ b/3-simple-monitoring/simple-monitoring.tf
@@ -1,5 +1,5 @@
 resource "sakuracloud_simple_monitor" "dev-mon01" {
-    #target = "${sakuracloud_server.myserver.base_nw_ipaddress}"
+    #target = "${sakuracloud_server.myserver.ipaddress}"
     target = "<IP_ADDRESS_HERE>"
     health_check = {
         protocol = "http"

--- a/5-server-scale/server-scale.tf
+++ b/5-server-scale/server-scale.tf
@@ -23,10 +23,7 @@ resource "sakuracloud_disk" "disks"{
 
 
 data sakuracloud_archive "centos" {
-    filter = {
-        name   = "Tags"
-        values = ["current-stable", "arch-64bit", "distro-centos"]
-    }
+    os_type = "centos"
 }
 
 resource "sakuracloud_ssh_key" "key"{
@@ -36,9 +33,6 @@ resource "sakuracloud_ssh_key" "key"{
 }
 
 output "server_ip" {
-   value = ["${sakuracloud_server.servers.*.base_nw_ipaddress}"]
+    value = ["${sakuracloud_server.servers.*.ipaddress}"]
 }
-
-
-
 

--- a/6-web-db-switch/switch.tf
+++ b/6-web-db-switch/switch.tf
@@ -11,8 +11,8 @@ resource "sakuracloud_server" "web01" {
     memory = "1"
     disks = ["${sakuracloud_disk.web01.id}"]
     tags = ["@virtio-net-pci","step6"]
-    base_interface = "shared"
-    additional_interfaces = ["${sakuracloud_switch.local-sw01.id}"]
+    nic = "shared"
+    additional_nics = ["${sakuracloud_switch.local-sw01.id}"]
 }
 
 resource "sakuracloud_disk" "web01"{
@@ -32,8 +32,8 @@ resource "sakuracloud_server" "db01" {
     memory = "1"
     disks = ["${sakuracloud_disk.db01.id}"]
     tags = ["@virtio-net-pci","step6"]
-    base_interface = "shared"
-    additional_interfaces = ["${sakuracloud_switch.local-sw01.id}"]
+    nic = "shared"
+    additional_nics = ["${sakuracloud_switch.local-sw01.id}"]
 }
 
 resource "sakuracloud_disk" "db01"{
@@ -47,10 +47,7 @@ resource "sakuracloud_disk" "db01"{
 }
 
 data "sakuracloud_archive" "centos" {
-    filter = {
-        name   = "Tags"
-        values = ["current-stable", "arch-64bit", "distro-centos"]
-    }
+    os_type = "centos"
 }
 
 resource "sakuracloud_ssh_key" "terraform"{

--- a/7-load-balancing/README.md
+++ b/7-load-balancing/README.md
@@ -20,12 +20,18 @@
 VIP の情報を確認するには、コントロールパネルにアクセスするか、次のコマンドを実行します。
 
 ```
-$ terraform show | grep vars.vip
-  vars.vip = <IPアドレスが表示>
+$ terraform output vip
+  vip = <IPアドレスが表示>
 ```
 
 VIP を `curl` やブラウザで表示すると、2台のサーバの情報（`server0` または `server1`）を表示します（最小セッション方式のため、再読みしても同じホスト名が出る場合があります）。
 
+### curl で確認する例
+
+```
+$ curl http://$(terraform output vip)
+server0(またはserver1)
+```
 
 ## リファレンス
 

--- a/7-load-balancing/load-balancing.tf
+++ b/7-load-balancing/load-balancing.tf
@@ -1,10 +1,10 @@
 # データソース(アーカイブ)
 data sakuracloud_archive "centos" {
-    os_type="centos"
+    os_type = "centos"
 }
 
 # ディスク
-resource "sakuracloud_disk" "disks"{
+resource "sakuracloud_disk" "disks" {
     # 2台分
     count = 2
     # ディスク名
@@ -31,12 +31,12 @@ resource "sakuracloud_server" "servers" {
     tags = ["@virtio-net-pci"]
 
     # ルータ+スイッチを接続
-    base_interface = "${sakuracloud_internet.router.switch_id}"
+    nic = "${sakuracloud_internet.router.switch_id}"
 
     # eth0のIPアドレス/ネットマスク/ゲートウェイ設定
-    base_nw_ipaddress = "${sakuracloud_internet.router.nw_ipaddresses[count.index]}"
-    base_nw_mask_len = "${sakuracloud_internet.router.nw_mask_len}"
-    base_nw_gateway = "${sakuracloud_internet.router.nw_gateway}"
+    ipaddress = "${sakuracloud_internet.router.ipaddresses[count.index]}"
+    nw_mask_len = "${sakuracloud_internet.router.nw_mask_len}"
+    gateway = "${sakuracloud_internet.router.gateway}"
 }
 
 # ルータ+スイッチ
@@ -59,7 +59,7 @@ data "template_file" "lb_dsr_tmpl" {
 
   vars {
     # ルータ+スイッチのグローバルIPを参照しテンプレートに渡す
-    vip = "${sakuracloud_internet.router.nw_ipaddresses[3]}"
+    vip = "${sakuracloud_internet.router.ipaddresses[3]}"
   }
 }
 
@@ -82,9 +82,9 @@ resource "sakuracloud_load_balancer" "lb" {
     VRID = 1
 
     # IPv4アドレス#1 / ネットマスク / ゲートウェイ
-    ipaddress1 = "${sakuracloud_internet.router.nw_ipaddresses[2]}"
+    ipaddress1 = "${sakuracloud_internet.router.ipaddresses[2]}"
     nw_mask_len = "${sakuracloud_internet.router.nw_mask_len}"
-    default_route = "${sakuracloud_internet.router.nw_gateway}"
+    default_route = "${sakuracloud_internet.router.gateway}"
 }
 
 # ロードバランサーのVIP
@@ -93,7 +93,7 @@ resource "sakuracloud_load_balancer_vip" "vip" {
     load_balancer_id = "${sakuracloud_load_balancer.lb.id}"
 
     # VIP
-    vip = "${sakuracloud_internet.router.nw_ipaddresses[3]}"
+    vip = "${sakuracloud_internet.router.ipaddresses[3]}"
 
     # 監視ポート
     port = 80
@@ -108,10 +108,15 @@ resource "sakuracloud_load_balancer_server" "servers"{
     load_balancer_vip_id = "${sakuracloud_load_balancer_vip.vip.id}"
 
     # 実サーバーのIPアドレス
-    ipaddress = "${sakuracloud_server.servers.*.base_nw_ipaddress[count.index]}"
+    ipaddress = "${sakuracloud_server.servers.*.ipaddress[count.index]}"
 
     # 監視設定
     check_protocol = "http"
     check_path = "/"
     check_status = "200"
+}
+
+# ロードバランサーのVIP用アウトプット定義
+output vip {
+    value = "${sakuracloud_load_balancer_vip.vip.vip}"
 }

--- a/README.md
+++ b/README.md
@@ -57,7 +57,7 @@ $ sh ./terraform-setup.sh
 6. Terraform の動作確認（バージョン情報の表示）
 ```
 $ terraform version
-Terraform v0.9.2
+Terraform v0.9.4
 ```
 
 ### 4. 環境変数の設定
@@ -109,14 +109,15 @@ $ ssh-keygen -t rsa
   * https://www.terraform.io/
 * Terraform for さくらのクラウド
   * https://github.com/yamamoto-febc/terraform-provider-sakuracloud
-* Terraform for さくらのクラウド スタートガイド （第一回） ～インストールから基本操作 ～ - さくらのナレッジ
+* Terraform for さくらのクラウド スタートガイド （第一回）～インストールから基本操作 ～ - さくらのナレッジ
   * http://knowledge.sakura.ad.jp/knowledge/7230/
-* Terraform for さくらのクラウド スタートガイド （第二回） ～便利なビルトイン機能～ - さくらのナレッジ
+* Terraform for さくらのクラウド スタートガイド （第二回）～便利なビルトイン機能～ - さくらのナレッジ
   * http://knowledge.sakura.ad.jp/knowledge/7550/
 * Terraform for さくらのクラウド スタートガイド （第三回）〜さくらのクラウド上にインフラ構築〜 - さくらのナレッジ
   * http://knowledge.sakura.ad.jp/knowledge/7660/
 * Terraform for さくらのクラウド スタートガイド （第四回）〜ネットワークの構築〜 - さくらのナレッジ
   * http://knowledge.sakura.ad.jp/knowledge/8248/
-
-
+* Terraform for さくらのクラウド スタートガイド （第五回）〜サービス提供用のリソースと応用編〜 - さくらのナレッジ
+  * http://knowledge.sakura.ad.jp/knowledge/8581/
+   
 

--- a/terraform-setup.sh
+++ b/terraform-setup.sh
@@ -5,13 +5,13 @@ mkdir ~/tmp/
 
 # Terraform
 cd ~/tmp/
-curl -L https://releases.hashicorp.com/terraform/0.9.2/terraform_0.9.2_linux_amd64.zip > terraform.zip
+curl -L https://releases.hashicorp.com/terraform/0.9.4/terraform_0.9.4_linux_amd64.zip > terraform.zip
 unzip terraform.zip
 mv ./terraform ~/bin
 
 
 # provider sakuracloud
-curl -L https://github.com/yamamoto-febc/terraform-provider-sakuracloud/releases/download/v0.7.3/terraform-provider-sakuracloud_linux-amd64.zip > terraform-provider-sakuracloud.zip
+curl -L https://github.com/yamamoto-febc/terraform-provider-sakuracloud/releases/download/v0.9.0/terraform-provider-sakuracloud_linux-amd64.zip > terraform-provider-sakuracloud.zip
 unzip terraform-provider-sakuracloud.zip
 mv ./terraform-provider-sakuracloud ~/bin
 


### PR DESCRIPTION
## 概要

Terraform for さくらのクラウドがバージョンアップされ`v0.9.0`となりました。
https://github.com/yamamoto-febc/terraform-provider-sakuracloud/releases/tag/v0.9.0

`v0.9.0`ではいくつかのリソースで属性名がよりシンプルになるといった変更が行われています。

このPRでは最新バージョンである`v0.9.0`を利用し、`.tf`ファイルをより簡潔に記載するように修正を行っています。

## 主な変更/修正点

- `v0.9.0`で変更された属性名を利用するように修正
- [`os_type`パラメータ](https://yamamoto-febc.github.io/terraform-provider-sakuracloud/configuration/resources/data_resource/#_4)やoutputを利用してより簡潔に記載するように`.tf`ファイルなどを修正
- Terraform(本体)のバージョンを`v0.9.4`へ修正
- [README.md](https://github.com/zembutsu/sakura-terraform/blob/master/README.md)に記載されている`リファレンス`に最新記事を追加
